### PR TITLE
Style the sessions#new login page

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,11 +1,41 @@
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
-<%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
+<section class="mx-auto w-full max-w-md py-8 sm:py-12">
+  <div class="card border border-base-300 bg-base-100 shadow-xl">
+    <div class="card-body gap-5">
+      <header class="space-y-2 text-center">
+        <h1 class="text-2xl font-semibold">Welcome back</h1>
+        <p class="text-sm opacity-75">Sign in to continue to your BankCORE workspace.</p>
+      </header>
 
-<%= form_with url: session_path do |form| %>
-  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
-  <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %><br>
-  <%= form.submit "Sign in" %>
-<% end %>
-<br>
+      <%= form_with url: session_path, class: "space-y-4" do |form| %>
+        <label class="form-control w-full">
+          <span class="label-text mb-1 font-medium">Email address</span>
+          <%= form.email_field :email_address,
+            required: true,
+            autofocus: true,
+            autocomplete: "username",
+            placeholder: "name@bankcore.com",
+            value: params[:email_address],
+            class: "input input-bordered w-full" %>
+        </label>
 
-<%= link_to "Forgot password?", new_password_path %>
+        <label class="form-control w-full">
+          <span class="label-text mb-1 font-medium">Password</span>
+          <%= form.password_field :password,
+            required: true,
+            autocomplete: "current-password",
+            placeholder: "Enter your password",
+            maxlength: 72,
+            class: "input input-bordered w-full" %>
+        </label>
+
+        <div class="pt-2">
+          <%= form.submit "Sign in", class: "btn btn-primary w-full" %>
+        </div>
+      <% end %>
+
+      <div class="text-center text-sm">
+        <%= link_to "Forgot password?", new_password_path, class: "link link-hover link-primary" %>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Improve the sign-in experience by converting the `sessions#new` view into a centered, card-style login UI that uses the app's existing Tailwind/DaisyUI utilities and matches the app's visual hierarchy.

### Description
- Replaced the minimal inline form with a centered card containing a header (`Welcome back`), labeled email and password fields using `input input-bordered w-full`, a full-width primary submit button (`btn btn-primary w-full`), and a styled forgot-password link; removed inline flash rendering since the global layout handles flashes.

### Testing
- Ran `bundle install` and it completed successfully.
- Ran `bin/rails test test/controllers/sessions_controller_test.rb` which failed in this environment due to missing local MySQL socket (`/var/run/mysqld/mysqld.sock`).
- Requested the endpoint with `curl -I http://127.0.0.1:3000/session/new` which returned `500 Internal Server Error` because the app cannot connect to the database in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9a3222c4832c8f7d7b480f38ee44)