### PR TITLE
Reverse transaction

### DIFF
--- a/app/controllers/concerns/posting_prerequisites.rb
+++ b/app/controllers/concerns/posting_prerequisites.rb
@@ -25,6 +25,7 @@ module PostingPrerequisites
 
     def drawer_required_for_request?
       transaction_type = params[:transaction_type].to_s.presence || inferred_transaction_type
+      return true if transaction_type == "reversal"
       return params[:draft_funding_source].to_s == "cash" if transaction_type == "draft"
       if transaction_type == "vault_transfer"
         direction = params[:vault_transfer_direction].to_s
@@ -50,6 +51,8 @@ module PostingPrerequisites
         "draft"
       when "teller/check_cashings"
         "check_cashing"
+      when "teller/reversals"
+        "reversal"
       when "teller/transaction_pages"
         case action_name
         when "deposit"

--- a/app/controllers/concerns/teller_posting_execution.rb
+++ b/app/controllers/concerns/teller_posting_execution.rb
@@ -15,6 +15,7 @@ module TellerPostingExecution
         return
       end
 
+      approved_by_user_id = nil
       if approval_required?(request_params)
         token = request_params[:approval_token].to_s
         if token.blank?
@@ -28,6 +29,7 @@ module TellerPostingExecution
             render json: { ok: false, error: "Approval token does not match request" }, status: :unprocessable_entity
             return
           end
+          approved_by_user_id = payload["supervisor_user_id"]
         rescue ActiveSupport::MessageVerifier::InvalidSignature
           render json: { ok: false, error: "Approval token is invalid or expired" }, status: :unprocessable_entity
           return
@@ -44,7 +46,8 @@ module TellerPostingExecution
         amount_cents: request_params[:amount_cents],
         entries: normalized_entries(request_params),
         metadata: posting_metadata(request_params),
-        currency: request_params[:currency].presence || "USD"
+        currency: request_params[:currency].presence || "USD",
+        approved_by_user_id: approved_by_user_id
       ).call
 
       render json: {

--- a/app/controllers/teller/receipts_controller.rb
+++ b/app/controllers/teller/receipts_controller.rb
@@ -20,7 +20,19 @@ module Teller
 
       def load_posting_batch
         @posting_batch = PostingBatch
-          .includes(:posting_legs, { account_transactions: :account }, teller_transaction: [ :branch, :workstation, :user, { teller_session: :cash_location } ])
+          .includes(
+            :posting_legs,
+            { account_transactions: :account },
+            teller_transaction: [
+              :branch,
+              :workstation,
+              :user,
+              :approved_by_user,
+              :reversed_by_teller_transaction,
+              :reversal_of_teller_transaction,
+              { teller_session: :cash_location }
+            ]
+          )
           .find_by!(request_id: params[:request_id].to_s)
       end
   end

--- a/app/controllers/teller/reversals_controller.rb
+++ b/app/controllers/teller/reversals_controller.rb
@@ -1,0 +1,86 @@
+module Teller
+  class ReversalsController < BaseController
+    include PostingPrerequisites
+
+    before_action :load_original_transaction
+    before_action :ensure_reversible
+    before_action :ensure_authorized
+    before_action :require_posting_context!, only: [ :create ]
+
+    def new
+      @reversal_reason_codes = reversal_reason_codes
+    end
+
+    def create
+      payload = verify_approval_token!
+      batch = Posting::ReversalService.new(
+        user: Current.user,
+        teller_session: current_teller_session,
+        branch: current_branch,
+        workstation: current_workstation,
+        original_teller_transaction_id: @original_transaction.id,
+        reversal_reason_code: params[:reversal_reason_code].to_s.strip,
+        reversal_memo: params[:reversal_memo].to_s.strip,
+        request_id: params[:request_id].presence || "reversal-#{@original_transaction.id}-#{Time.current.to_i}-#{SecureRandom.hex(4)}",
+        approved_by_user_id: payload["supervisor_user_id"]
+      ).call
+
+      redirect_to teller_receipt_path(request_id: batch.request_id),
+        notice: "Reversal posted successfully."
+    rescue Posting::ReversalService::Error, Posting::ReversalRecipeBuilder::Error => e
+      @reversal_reason_codes = reversal_reason_codes
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    rescue ActiveRecord::RecordInvalid => e
+      @reversal_reason_codes = reversal_reason_codes
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    private
+      def load_original_transaction
+        @original_transaction = TellerTransaction.find_by(id: params[:id])
+        return if @original_transaction.present?
+
+        redirect_to teller_root_path, alert: "Transaction not found."
+      end
+
+      def ensure_reversible
+        return if @original_transaction&.reversible?
+
+        redirect_to teller_root_path, alert: "This transaction cannot be reversed."
+      end
+
+      def ensure_authorized
+        authorize([ :teller, :posting ], :create?)
+      end
+
+      def verify_approval_token!
+        token = params[:approval_token].to_s
+        raise Posting::ReversalService::Error, "Supervisor approval is required" if token.blank?
+
+        payload = approval_verifier.verify(token)
+        if payload["policy_trigger"].to_s != "transaction_reversal"
+          raise Posting::ReversalService::Error, "Invalid approval token for reversal"
+        end
+        payload
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
+        raise Posting::ReversalService::Error, "Approval token is invalid or expired"
+      end
+
+      def approval_verifier
+        @approval_verifier ||= ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base, serializer: JSON)
+      end
+
+      def reversal_reason_codes
+        [
+          [ "Entry error", "ENTRY_ERROR" ],
+          [ "Duplicate transaction", "DUPLICATE" ],
+          [ "Customer request", "CUSTOMER_REQUEST" ],
+          [ "Wrong account", "WRONG_ACCOUNT" ],
+          [ "Wrong amount", "WRONG_AMOUNT" ],
+          [ "Other", "OTHER" ]
+        ]
+      end
+  end
+end

--- a/app/javascript/controllers/reversal_form_controller.js
+++ b/app/javascript/controllers/reversal_form_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form", "requestId", "approvalToken", "reasonCode", "memo", "errorMessage"]
+
+  submitReversal() {
+    this.hideError()
+    if (!this.hasReasonCodeTarget || !this.reasonCodeTarget.value) {
+      this.showError("Reason code is required")
+      return
+    }
+    if (!this.hasMemoTarget || !this.memoTarget.value.trim()) {
+      this.showError("Memo is required")
+      return
+    }
+
+    const policyContext = {
+      original_teller_transaction_id: this.element.dataset.originalTransactionId || "",
+      original_ref: this.element.dataset.originalRef || "",
+      original_amount: this.element.dataset.originalAmount || "",
+      original_type: this.element.dataset.originalType || ""
+    }
+
+    this.element.dispatchEvent(new CustomEvent("tx:approval-required", {
+      bubbles: true,
+      detail: {
+        policyTrigger: "transaction_reversal",
+        policyContext,
+        reason: "Reversal requires supervisor approval"
+      }
+    }))
+  }
+
+  handleApprovalGranted(event) {
+    const token = event.detail?.approvalToken
+    if (token && this.hasApprovalTokenTarget) {
+      this.approvalTokenTarget.value = token
+    }
+    if (this.hasFormTarget) {
+      this.formTarget.requestSubmit()
+    }
+  }
+
+  handleApprovalError(event) {
+    const message = event.detail?.message || "Approval failed"
+    this.showError(message)
+  }
+
+  showError(message) {
+    if (this.hasErrorMessageTarget) {
+      this.errorMessageTarget.textContent = message
+      this.errorMessageTarget.classList.remove("hidden")
+    }
+  }
+
+  hideError() {
+    if (this.hasErrorMessageTarget) {
+      this.errorMessageTarget.textContent = ""
+      this.errorMessageTarget.classList.add("hidden")
+    }
+  }
+
+  dispatch(name, options = {}) {
+    this.element.dispatchEvent(new CustomEvent(name, { bubbles: true, ...options }))
+  }
+}

--- a/app/models/posting_batch.rb
+++ b/app/models/posting_batch.rb
@@ -4,6 +4,8 @@ class PostingBatch < ApplicationRecord
   attribute :metadata, :json, default: {}
 
   belongs_to :teller_transaction
+  belongs_to :reversal_of_posting_batch, class_name: "PostingBatch", optional: true
+  has_one :reversed_by_posting_batch, class_name: "PostingBatch", foreign_key: :reversal_of_posting_batch_id
   has_many :posting_legs, dependent: :destroy
   has_many :account_transactions, dependent: :destroy
 

--- a/app/models/teller_transaction.rb
+++ b/app/models/teller_transaction.rb
@@ -1,14 +1,20 @@
 class TellerTransaction < ApplicationRecord
-  TRANSACTION_TYPES = %w[deposit withdrawal transfer vault_transfer draft check_cashing session_close_variance session_handoff_variance].freeze
+  NON_REVERSIBLE_TYPES = %w[session_close_variance session_handoff_variance reversal].freeze
+  TRANSACTION_TYPES = %w[deposit withdrawal transfer vault_transfer draft check_cashing session_close_variance session_handoff_variance reversal].freeze
   STATUSES = %w[posted failed].freeze
 
   belongs_to :user
   belongs_to :teller_session
   belongs_to :branch
   belongs_to :workstation
+  belongs_to :approved_by_user, class_name: "User", optional: true
+  belongs_to :reversal_of_teller_transaction, class_name: "TellerTransaction", optional: true
+  has_one :reversed_by_teller_transaction, class_name: "TellerTransaction", foreign_key: :reversal_of_teller_transaction_id
   has_one :posting_batch, dependent: :destroy
   has_many :cash_movements, dependent: :destroy
   has_many :account_transactions, dependent: :destroy
+
+  scope :reversible, -> { where(transaction_type: TRANSACTION_TYPES - NON_REVERSIBLE_TYPES).where(reversed_by_teller_transaction_id: nil) }
 
   validates :transaction_type, inclusion: { in: TRANSACTION_TYPES }
   validates :request_id, presence: true, uniqueness: true
@@ -16,4 +22,15 @@ class TellerTransaction < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
   validates :amount_cents, numericality: { greater_than: 0 }
   validates :posted_at, presence: true
+
+  def reversed?
+    reversed_by_teller_transaction_id.present?
+  end
+
+  def reversible?
+    return false if NON_REVERSIBLE_TYPES.include?(transaction_type)
+    return false if reversed?
+
+    true
+  end
 end

--- a/app/policies/teller/posting_policy.rb
+++ b/app/policies/teller/posting_policy.rb
@@ -9,7 +9,8 @@ module Teller
         "transactions.transfer.create",
         "transactions.vault_transfer.create",
         "transactions.draft.create",
-        "transactions.check_cashing.create"
+        "transactions.check_cashing.create",
+        "transactions.reversal.create"
       ].any? do |permission_key|
         user.has_permission?(permission_key, branch: Current.branch, workstation: Current.workstation)
       end

--- a/app/services/posting/committer.rb
+++ b/app/services/posting/committer.rb
@@ -25,7 +25,7 @@ module Posting
       attr_reader :request, :legs
 
       def create_teller_transaction!
-        TellerTransaction.create!(
+        attrs = {
           user: request.fetch(:user),
           teller_session: request.fetch(:teller_session),
           branch: request.fetch(:branch),
@@ -36,7 +36,9 @@ module Posting
           amount_cents: request.fetch(:amount_cents),
           status: "posted",
           posted_at: Time.current
-        )
+        }
+        attrs[:approved_by_user_id] = request[:approved_by_user_id] if request[:approved_by_user_id].present?
+        TellerTransaction.create!(attrs)
       end
 
       def create_posting_batch!(teller_transaction)

--- a/app/services/posting/engine.rb
+++ b/app/services/posting/engine.rb
@@ -4,7 +4,7 @@ module Posting
 
     attr_reader :request
 
-    def initialize(user:, teller_session:, branch:, workstation:, request_id:, transaction_type:, amount_cents:, entries:, metadata: {}, currency: "USD")
+    def initialize(user:, teller_session:, branch:, workstation:, request_id:, transaction_type:, amount_cents:, entries:, metadata: {}, currency: "USD", approved_by_user_id: nil)
       @request = build_request(
         user: user,
         teller_session: teller_session,
@@ -15,7 +15,8 @@ module Posting
         amount_cents: amount_cents,
         entries: entries,
         metadata: metadata,
-        currency: currency
+        currency: currency,
+        approved_by_user_id: approved_by_user_id
       )
     end
 
@@ -33,7 +34,7 @@ module Posting
     end
 
     private
-      def build_request(user:, teller_session:, branch:, workstation:, request_id:, transaction_type:, amount_cents:, entries:, metadata:, currency:)
+      def build_request(user:, teller_session:, branch:, workstation:, request_id:, transaction_type:, amount_cents:, entries:, metadata:, currency:, approved_by_user_id: nil)
         {
           user: user,
           teller_session: teller_session,
@@ -44,6 +45,7 @@ module Posting
           amount_cents: amount_cents.to_i,
           metadata: metadata.presence || {},
           currency: currency.to_s,
+          approved_by_user_id: approved_by_user_id,
           entries: Array(entries).map.with_index do |entry, index|
             {
               side: entry.fetch(:side).to_s,

--- a/app/services/posting/reversal_recipe_builder.rb
+++ b/app/services/posting/reversal_recipe_builder.rb
@@ -1,0 +1,38 @@
+module Posting
+  class ReversalRecipeBuilder
+    class Error < StandardError; end
+
+    def initialize(original_teller_transaction:)
+      @original_teller_transaction = original_teller_transaction
+    end
+
+    def entries
+      validate_original!
+      original_batch.posting_legs.order(:position).map.with_index do |leg, index|
+        {
+          side: inverted_side(leg.side),
+          account_reference: leg.account_reference,
+          amount_cents: leg.amount_cents,
+          position: index
+        }
+      end
+    end
+
+    private
+      attr_reader :original_teller_transaction
+
+      def original_batch
+        @original_batch ||= original_teller_transaction.posting_batch
+      end
+
+      def validate_original!
+        raise Error, "Original transaction is not reversible" unless original_teller_transaction.reversible?
+        raise Error, "Original transaction has no posting batch" if original_batch.blank?
+        raise Error, "Original transaction is not posted" unless original_teller_transaction.status == "posted"
+      end
+
+      def inverted_side(side)
+        side == "debit" ? "credit" : "debit"
+      end
+  end
+end

--- a/app/services/posting/reversal_service.rb
+++ b/app/services/posting/reversal_service.rb
@@ -1,0 +1,152 @@
+module Posting
+  class ReversalService
+    class Error < StandardError; end
+
+    def initialize(
+      user:,
+      teller_session:,
+      branch:,
+      workstation:,
+      original_teller_transaction_id:,
+      reversal_reason_code:,
+      reversal_memo:,
+      request_id:,
+      approved_by_user_id: nil
+    )
+      @user = user
+      @teller_session = teller_session
+      @branch = branch
+      @workstation = workstation
+      @original_teller_transaction_id = original_teller_transaction_id
+      @reversal_reason_code = reversal_reason_code
+      @reversal_memo = reversal_memo
+      @request_id = request_id.to_s
+      @approved_by_user_id = approved_by_user_id
+    end
+
+    def call
+      existing_batch = PostingBatch.find_by(request_id: request_id)
+      return existing_batch if existing_batch.present?
+
+      original = TellerTransaction.find_by(id: original_teller_transaction_id)
+      raise Error, "Original transaction not found" if original.blank?
+
+      legs = ReversalRecipeBuilder.new(original_teller_transaction: original).entries
+      Posting::BalanceChecker.call(legs: legs, error_class: Error)
+
+      request = build_request(original: original, legs: legs)
+      Posting::PolicyChecker.call(request: request, error_class: Error)
+
+      ActiveRecord::Base.transaction do
+        reversal_transaction = create_reversal_transaction!(original)
+        reversal_batch = create_reversal_batch!(reversal_transaction, original)
+        persist_legs_and_account_transactions!(reversal_batch, reversal_transaction, legs)
+        Posting::Effects::CashMovementRecorder.new(
+          request: request,
+          legs: legs,
+          teller_transaction: reversal_transaction
+        ).call
+        original.update!(
+          reversed_by_teller_transaction_id: reversal_transaction.id,
+          reversed_at: Time.current
+        )
+        reversal_batch
+      end
+    rescue ActiveRecord::RecordNotUnique
+      PostingBatch.find_by!(request_id: request_id)
+    end
+
+    private
+      attr_reader :user, :teller_session, :branch, :workstation,
+        :original_teller_transaction_id, :reversal_reason_code, :reversal_memo, :request_id,
+        :approved_by_user_id
+
+      def build_request(original:, legs:)
+        {
+          user: user,
+          teller_session: teller_session,
+          branch: branch,
+          workstation: workstation,
+          request_id: request_id,
+          transaction_type: "reversal",
+          amount_cents: original.amount_cents,
+          currency: original.currency,
+          metadata: {
+            reversal: {
+              original_teller_transaction_id: original.id,
+              original_request_id: original.request_id,
+              original_transaction_type: original.transaction_type,
+              reason_code: reversal_reason_code,
+              memo: reversal_memo,
+              approved_by_user_id: approved_by_user_id
+            }
+          },
+          entries: legs
+        }
+      end
+
+      def create_reversal_transaction!(original)
+        TellerTransaction.create!(
+          user: user,
+          teller_session: teller_session,
+          branch: branch,
+          workstation: workstation,
+          request_id: request_id,
+          transaction_type: "reversal",
+          currency: original.currency,
+          amount_cents: original.amount_cents,
+          status: "posted",
+          posted_at: Time.current,
+          reversal_of_teller_transaction_id: original.id,
+          reversal_reason_code: reversal_reason_code,
+          reversal_memo: reversal_memo,
+          approved_by_user_id: approved_by_user_id
+        )
+      end
+
+      def create_reversal_batch!(reversal_transaction, original)
+        PostingBatch.create!(
+          teller_transaction: reversal_transaction,
+          request_id: request_id,
+          currency: original.currency,
+          status: "committed",
+          committed_at: Time.current,
+          metadata: {
+            reversal: {
+              original_teller_transaction_id: original.id,
+              original_request_id: original.request_id,
+              original_transaction_type: original.transaction_type,
+              reason_code: reversal_reason_code,
+              memo: reversal_memo,
+              approved_by_user_id: approved_by_user_id
+            }
+          },
+          reversal_of_posting_batch_id: original.posting_batch.id
+        )
+      end
+
+      def persist_legs_and_account_transactions!(posting_batch, teller_transaction, legs)
+        legs.each do |leg|
+          account_reference = leg.fetch(:account_reference)
+          account_id = Account.find_by(account_number: account_reference)&.id
+
+          PostingLeg.create!(
+            posting_batch: posting_batch,
+            side: leg.fetch(:side),
+            account_reference: account_reference,
+            amount_cents: leg.fetch(:amount_cents),
+            position: leg.fetch(:position)
+          )
+
+          AccountTransaction.create!(
+            teller_transaction: teller_transaction,
+            posting_batch: posting_batch,
+            account_reference: account_reference,
+            account_id: account_id,
+            direction: leg.fetch(:side),
+            amount_cents: leg.fetch(:amount_cents)
+          )
+        end
+      end
+  end
+end

--- a/app/views/ops/sessions/show.html.erb
+++ b/app/views/ops/sessions/show.html.erb
@@ -121,10 +121,24 @@
           <% if @transactions.any? %>
             <% @transactions.each do |tx| %>
               <% cash_impact = tx.cash_movements.sum { |m| m.direction == "in" ? m.amount_cents : -m.amount_cents } %>
-              <tr>
+              <tr class="<%= tx.transaction_type == "reversal" ? "bg-slate-50 dark:bg-slate-800/50" : "" %>">
                 <td><%= tx.posted_at&.strftime("%Y-%m-%d %H:%M") || "—" %></td>
-                <td><%= tx.transaction_type.humanize %></td>
-                <td class="mono text-sm"><%= tx.request_id %></td>
+                <td>
+                  <%= tx.transaction_type.humanize %>
+                  <% if tx.transaction_type == "reversal" %>
+                    <span class="badge badge-ghost text-xs ml-1">Reversal</span>
+                  <% elsif tx.reversed? %>
+                    <span class="badge badge-ghost text-xs ml-1">Reversed</span>
+                  <% end %>
+                </td>
+                <td class="mono text-sm">
+                  <%= tx.request_id %>
+                  <% if tx.transaction_type == "reversal" && tx.reversal_of_teller_transaction.present? %>
+                    <br><span class="text-xs text-slate-500">Reverses <%= tx.reversal_of_teller_transaction.request_id %></span>
+                  <% elsif tx.reversed? && tx.reversed_by_teller_transaction.present? %>
+                    <br><span class="text-xs text-slate-500">Reversed by <%= link_to tx.reversed_by_teller_transaction.request_id, teller_receipt_path(request_id: tx.reversed_by_teller_transaction.request_id), class: "link link-hover", target: "_blank" %></span>
+                  <% end %>
+                </td>
                 <td class="text-right ui-money mono"><%= money[tx.amount_cents] %></td>
                 <td class="text-right ui-money mono">
                   <% if cash_impact != 0 %>
@@ -136,7 +150,7 @@
                   <% end %>
                 </td>
                 <td>
-                  <%= link_to "Receipt", teller_receipt_path(tx.request_id), class: "btn btn-ghost btn-xs", target: "_blank" %>
+                  <%= link_to "Receipt", teller_receipt_path(request_id: tx.request_id), class: "btn btn-ghost btn-xs", target: "_blank" %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/teller/dashboard/_recent_transactions.html.erb
+++ b/app/views/teller/dashboard/_recent_transactions.html.erb
@@ -32,13 +32,21 @@
                 <td class="py-2 text-right tabular-nums <%= signed_cents.negative? ? 'text-error font-medium' : 'ui-money' %>">
                   <%= signed_cents.negative? ? "" : "+" %><%= number_to_currency(signed_cents / 100.0) %>
                 </td>
-                <td class="py-2"><span class="badge badge-outline"><%= transaction.status %></span></td>
+                <td class="py-2">
+                  <span class="badge badge-outline"><%= transaction.status %></span>
+                  <% if transaction.reversed? %>
+                    <span class="badge badge-ghost text-xs ml-1">Reversed</span>
+                  <% end %>
+                </td>
                 <td class="py-2 text-xs tabular-nums"><%= transaction.request_id %></td>
                 <td class="no-print py-2 text-right">
                   <% if transaction.posting_batch.present? %>
                     <div class="flex gap-1 justify-end">
                       <%= link_to "Receipt", teller_receipt_path(request_id: transaction.request_id), class: "btn btn-ghost btn-sm" %>
                       <%= link_to "Audit", teller_receipt_path(request_id: transaction.request_id, view: "audit"), class: "btn btn-ghost btn-sm" %>
+                      <% if transaction.reversible? %>
+                        <%= link_to "Reverse", reversal_teller_transaction_path(transaction), class: "btn btn-outline btn-sm" %>
+                      <% end %>
                     </div>
                   <% else %>
                     <span class="text-slate-500 text-xs">—</span>

--- a/app/views/teller/receipts/_receipt_header.html.erb
+++ b/app/views/teller/receipts/_receipt_header.html.erb
@@ -21,4 +21,7 @@
   </table>
   <p class="divider"></p>
   <p class="text-xs text-center"> BR: <%= branch.code %> WS: <%= tt.workstation&.code %> S: <%= session_record&.id || "—" %> D: <%= drawer&.code || "—" %></p>
+  <% if tt.approved_by_user.present? %>
+    <p class="text-xs text-center">Authorizer: <%= tt.approved_by_user.display_label %> (<%= tt.approved_by_user.teller_number.presence || tt.approved_by_user.email_address %>)</p>
+  <% end %>
 </div>

--- a/app/views/teller/receipts/_reversal.html.erb
+++ b/app/views/teller/receipts/_reversal.html.erb
@@ -1,0 +1,91 @@
+<% meta = posting_batch.metadata || {} %>
+<% meta = meta.with_indifferent_access if meta.respond_to?(:with_indifferent_access) %>
+<% reversal_meta = meta.dig("reversal") || meta.dig(:reversal) || {} %>
+<% reversal_meta = reversal_meta.with_indifferent_access if reversal_meta.respond_to?(:with_indifferent_access) %>
+<% original_ref = reversal_meta["original_request_id"] || reversal_meta[:original_request_id] || "—" %>
+<% original_type = reversal_meta["original_transaction_type"] || reversal_meta[:original_transaction_type] || "—" %>
+<% reason_code = teller_transaction.reversal_reason_code || reversal_meta["reason_code"] || reversal_meta[:reason_code] || "—" %>
+<% memo = teller_transaction.reversal_memo || reversal_meta["memo"] || reversal_meta[:memo] || "—" %>
+<% original_tt = teller_transaction.reversal_of_teller_transaction %>
+
+<table class="table table-xs text-xs w-full">
+  <tr>
+    <td>Reverses:</td>
+    <td class="font-mono">
+      <% if original_tt.present? %>
+        <%= link_to original_ref, teller_receipt_path(request_id: original_tt.request_id), class: "link link-hover" %>
+      <% else %>
+        <%= original_ref %>
+      <% end %>
+    </td>
+  </tr>
+  <tr>
+    <td>Original Type:</td>
+    <td><%= original_type.to_s.titleize %></td>
+  </tr>
+  <% if original_tt.present? %>
+    <tr>
+      <td>Original Date:</td>
+      <td><%= original_tt.posted_at&.strftime("%m/%d/%Y %-l:%M%P") || "—" %></td>
+    </tr>
+    <tr>
+      <td>Original Teller:</td>
+      <td><%= original_tt.user&.display_label || "—" %></td>
+    </tr>
+  <% end %>
+  <tr>
+    <td>Amount:</td>
+    <td class="tabular-nums"><%= receipt_money(teller_transaction.amount_cents) %></td>
+  </tr>
+  <tr>
+    <td>Reason:</td>
+    <td><%= reason_code %></td>
+  </tr>
+  <tr>
+    <td>Memo:</td>
+    <td><%= memo %></td>
+  </tr>
+  <% if teller_transaction.approved_by_user.present? %>
+    <tr>
+      <td>Authorized by:</td>
+      <td><%= teller_transaction.approved_by_user.display_label %> (<%= teller_transaction.approved_by_user.teller_number.presence || teller_transaction.approved_by_user.email_address %>)</td>
+    </tr>
+  <% end %>
+</table>
+
+<section class="mt-3">
+  <h3 class="text-xs font-bold uppercase tracking-wide text-slate-500 mb-1">Reversal Legs</h3>
+  <table class="table table-xs text-xs w-full">
+    <thead>
+      <tr class="row-border t-head">
+        <th class="py-1 text-left">Side</th>
+        <th class="py-1 text-left">Account</th>
+        <th class="py-1 text-right">Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% posting_legs.each do |leg| %>
+        <tr class="row-border">
+          <td class="py-1"><%= leg.side %></td>
+          <td class="py-1 font-mono text-xs"><%= leg.account_reference %></td>
+          <td class="py-1 text-right tabular-nums"><%= receipt_money(leg.amount_cents) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>
+
+<% if @cash_movements.present? && @cash_movements.any? %>
+  <section class="mt-3">
+    <h3 class="text-xs font-bold uppercase tracking-wide text-slate-500 mb-1">Cash Impact</h3>
+    <table class="table table-xs text-xs w-full">
+      <% @cash_movements.each do |mov| %>
+        <tr>
+          <td><%= mov.direction == "in" ? "Cash In" : "Cash Out" %></td>
+          <td><%= mov.cash_location&.code || "—" %></td>
+          <td class="text-right tabular-nums"><%= receipt_money(mov.amount_cents) %></td>
+        </tr>
+      <% end %>
+    </table>
+  </section>
+<% end %>

--- a/app/views/teller/receipts/audit.html.erb
+++ b/app/views/teller/receipts/audit.html.erb
@@ -4,10 +4,21 @@
       <div class="card-body py-3">
         <h2 class="card-title text-lg">Audit Receipt</h2>
         <p class="text-sm opacity-80">Full posting context, legs, and cash movements</p>
-        <p class="flex gap-2 flex-wrap">
-          <%= link_to "Back to Dashboard", teller_root_path, class: "btn btn-ghost btn-sm" %>
-          <%= link_to "Customer Receipt", teller_receipt_path(request_id: @posting_batch.request_id), class: "btn btn-outline btn-sm" %>
-          <button type="button" onclick="window.print()" class="btn btn-outline btn-sm">Print</button>
+        <p class="flex flex-wrap justify-between gap-2 items-center">
+          <span class="flex gap-2">
+            <% if @teller_transaction.reversible? %>
+              <%= link_to "Reverse", reversal_teller_transaction_path(@teller_transaction), class: "btn btn-outline btn-error btn-sm" %>
+            <% elsif @teller_transaction.reversed? %>
+              <%= link_to "Reversed by #{@teller_transaction.reversed_by_teller_transaction.request_id}", teller_receipt_path(request_id: @teller_transaction.reversed_by_teller_transaction.request_id, view: "audit"), class: "btn btn-ghost btn-sm" %>
+            <% elsif @teller_transaction.transaction_type == "reversal" && @teller_transaction.reversal_of_teller_transaction.present? %>
+              <%= link_to "Original #{@teller_transaction.reversal_of_teller_transaction.request_id}", teller_receipt_path(request_id: @teller_transaction.reversal_of_teller_transaction.request_id, view: "audit"), class: "btn btn-ghost btn-sm" %>
+            <% end %>
+          </span>
+          <span class="flex gap-2 flex-wrap">
+            <%= link_to "Customer Receipt", teller_receipt_path(request_id: @posting_batch.request_id), class: "btn btn-outline btn-sm" %>
+            <button type="button" onclick="window.print()" class="btn btn-secondary btn-sm">Print</button>
+            <%= link_to "Back to Dashboard", teller_root_path, class: "btn btn-ghost btn-sm" %>
+          </span>
         </p>
       </div>
     </section>
@@ -19,6 +30,25 @@
       <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm font-mono">
         <dt class="text-slate-500">Request ID</dt>
         <dd><%= @posting_batch.request_id %></dd>
+        <% if @teller_transaction.reversed? %>
+          <dt class="text-slate-500">Reversed by</dt>
+          <dd>
+            <%= link_to @teller_transaction.reversed_by_teller_transaction.request_id,
+              teller_receipt_path(request_id: @teller_transaction.reversed_by_teller_transaction.request_id, view: "audit"),
+              class: "link link-hover" %>
+          </dd>
+        <% elsif @teller_transaction.transaction_type == "reversal" && @teller_transaction.reversal_of_teller_transaction.present? %>
+          <dt class="text-slate-500">Reverses</dt>
+          <dd>
+            <%= link_to @teller_transaction.reversal_of_teller_transaction.request_id,
+              teller_receipt_path(request_id: @teller_transaction.reversal_of_teller_transaction.request_id, view: "audit"),
+              class: "link link-hover" %>
+          </dd>
+        <% end %>
+        <% if @teller_transaction.approved_by_user.present? %>
+          <dt class="text-slate-500">Authorized by</dt>
+          <dd><%= @teller_transaction.approved_by_user.display_label %> (<%= @teller_transaction.approved_by_user.teller_number.presence || @teller_transaction.approved_by_user.email_address %>)</dd>
+        <% end %>
         <dt class="text-slate-500">Status</dt>
         <dd><%= @posting_batch.status %> / <%= @teller_transaction.status %></dd>
         <dt class="text-slate-500">Branch</dt>

--- a/app/views/teller/receipts/show.html.erb
+++ b/app/views/teller/receipts/show.html.erb
@@ -4,10 +4,21 @@
       <div class="card-body py-3">
         <h2 class="card-title text-lg">Receipt</h2>
         <p class="text-sm opacity-80">Customer-facing transaction receipt</p>
-        <p class="flex gap-2 flex-wrap">
-          <%= link_to "Back to Dashboard", teller_root_path, class: "btn btn-ghost btn-sm" %>
-          <%= link_to "Audit View", teller_receipt_path(request_id: @posting_batch.request_id, view: "audit"), class: "btn btn-outline btn-sm" %>
-          <button type="button" onclick="window.print()" class="btn btn-outline btn-sm">Print</button>
+        <p class="flex flex-wrap justify-between gap-2 items-center">
+          <span class="flex gap-2">
+            <% if @teller_transaction.reversible? %>
+              <%= link_to "Reverse", reversal_teller_transaction_path(@teller_transaction), class: "btn btn-outline btn-error btn-sm" %>
+            <% elsif @teller_transaction.reversed? %>
+              <%= link_to "Reversed by #{@teller_transaction.reversed_by_teller_transaction.request_id}", teller_receipt_path(request_id: @teller_transaction.reversed_by_teller_transaction.request_id), class: "btn btn-ghost btn-sm" %>
+            <% elsif @teller_transaction.transaction_type == "reversal" && @teller_transaction.reversal_of_teller_transaction.present? %>
+              <%= link_to "Original #{@teller_transaction.reversal_of_teller_transaction.request_id}", teller_receipt_path(request_id: @teller_transaction.reversal_of_teller_transaction.request_id), class: "btn btn-ghost btn-sm" %>
+            <% end %>
+          </span>
+          <span class="flex gap-2 flex-wrap">
+            <%= link_to "Audit View", teller_receipt_path(request_id: @posting_batch.request_id, view: "audit"), class: "btn btn-outline btn-sm" %>
+            <button type="button" onclick="window.print()" class="btn btn-secondary btn-sm">Print</button>
+            <%= link_to "Back to Dashboard", teller_root_path, class: "btn btn-ghost btn-sm" %>
+          </span>
         </p>
       </div>
     </section>
@@ -17,6 +28,18 @@
     <%= render "teller/receipts/receipt_header", teller_transaction: @teller_transaction %>
 
     <h2 class="receipt-type-title text-lg font-bold mt-4 mb-2"><%= @teller_transaction.transaction_type.humanize.upcase %></h2>
+
+    <% if @teller_transaction.reversed? %>
+      <div class="alert alert-warning my-3" role="alert">
+        <p class="font-bold">REVERSED</p>
+        <p class="text-sm mt-1">
+          This transaction was reversed.
+          <%= link_to "View reversal receipt (#{@teller_transaction.reversed_by_teller_transaction.request_id})",
+            teller_receipt_path(request_id: @teller_transaction.reversed_by_teller_transaction.request_id),
+            class: "link link-hover font-medium" %>
+        </p>
+      </div>
+    <% end %>
 
     <% partial_name = @teller_transaction.transaction_type.to_s %>
     <% partial_path = "teller/receipts/#{partial_name}" %>

--- a/app/views/teller/reversals/new.html.erb
+++ b/app/views/teller/reversals/new.html.erb
@@ -1,0 +1,84 @@
+<%= render "teller/shared/page_header",
+  title: "Reversal",
+  description: "Reverse a previously posted transaction. Requires supervisor approval.",
+  secondary_button_path: teller_root_path,
+  secondary_button_label: "Cancel" %>
+
+<div data-controller="reversal-form approval-panel"
+  data-approval-panel-approval-url-value="<%= teller_approvals_path %>"
+  data-action="tx:approval-required->approval-panel#show tx:approval-granted->reversal-form#handleApprovalGranted tx:approval-error->reversal-form#handleApprovalError"
+  data-original-transaction-id="<%= @original_transaction.id %>"
+  data-original-ref="<%= @original_transaction.request_id %>"
+  data-original-amount="<%= @original_transaction.amount_cents %>"
+  data-original-type="<%= @original_transaction.transaction_type %>">
+  <%= render "teller/shared/approval_modal" %>
+
+  <section class="card bg-base-100 border border-base-300">
+    <div class="card-body">
+      <h2 class="card-title text-base">Original Transaction</h2>
+      <div class="divider my-2"></div>
+      <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+        <dt class="text-slate-500">Ref #</dt>
+        <dd class="font-mono"><%= @original_transaction.request_id %></dd>
+        <dt class="text-slate-500">Type</dt>
+        <dd><%= @original_transaction.transaction_type.titleize %></dd>
+        <dt class="text-slate-500">Amount</dt>
+        <dd class="tabular-nums"><%= number_to_currency(@original_transaction.amount_cents / 100.0) %></dd>
+        <dt class="text-slate-500">Posted</dt>
+        <dd><%= @original_transaction.posted_at.strftime("%b %-d, %Y at %-l:%M %p") %></dd>
+        <dt class="text-slate-500">Teller</dt>
+        <dd><%= @original_transaction.user.display_label %></dd>
+        <dt class="text-slate-500">Session</dt>
+        <dd><%= @original_transaction.teller_session_id %> <%= @original_transaction.teller_session.closed? ? "(closed)" : "" %></dd>
+      </dl>
+      <% if @original_transaction.teller_session.closed? %>
+        <p class="mt-3 text-sm text-slate-600 bg-slate-100 dark:bg-slate-800 p-2 rounded">
+          This reversal will post to the current open session.
+        </p>
+      <% end %>
+    </div>
+  </section>
+
+  <%= form_with url: reversal_teller_transaction_path(@original_transaction), method: :post, html: { id: "reversal-form", data: { reversal_form_target: "form" } } do |form| %>
+    <section class="card bg-base-100 border border-base-300 mt-4">
+      <div class="card-body">
+        <h2 class="card-title text-base">Reversal Details</h2>
+        <div class="divider my-2"></div>
+
+        <% if flash[:alert].present? %>
+          <p class="alert alert-error text-sm"><%= flash[:alert] %></p>
+        <% end %>
+        <p class="alert alert-error text-sm hidden" data-reversal-form-target="errorMessage" role="alert"></p>
+
+        <%= form.hidden_field :request_id, value: "reversal-#{@original_transaction.id}-#{Time.current.to_i}-#{SecureRandom.hex(4)}", data: { reversal_form_target: "requestId", posting_form_target: "requestId" } %>
+        <%= form.hidden_field :approval_token, value: "", data: { reversal_form_target: "approvalToken" } %>
+
+        <div class="form-control">
+          <%= form.label :reversal_reason_code, "Reason Code", class: "text-xs font-medium text-slate-700" %>
+          <%= form.select :reversal_reason_code,
+            options_for_select(@reversal_reason_codes, params[:reversal_reason_code]),
+            { include_blank: "Select reason" },
+            { required: true, class: "select select-bordered w-full", data: { reversal_form_target: "reasonCode" } } %>
+        </div>
+
+        <div class="form-control mt-3">
+          <%= form.label :reversal_memo, "Memo", class: "text-xs font-medium text-slate-700" %>
+          <%= form.text_area :reversal_memo,
+            required: true,
+            rows: 3,
+            placeholder: "Required narrative explaining the reversal",
+            class: "textarea textarea-bordered w-full",
+            data: { reversal_form_target: "memo" },
+            value: params[:reversal_memo] %>
+        </div>
+
+        <div class="modal-action mt-4 px-0">
+          <%= link_to "Cancel", teller_root_path, class: "btn btn-ghost" %>
+          <button type="button" class="btn btn-primary" data-action="click->reversal-form#submitReversal">
+            Reverse (Post)
+          </button>
+        </div>
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/app/views/teller/transaction_history/index.html.erb
+++ b/app/views/teller/transaction_history/index.html.erb
@@ -37,13 +37,21 @@
                 <td class="py-2 text-right mono tabular-nums <%= signed_cents.negative? ? 'text-error font-medium' : 'ui-money' %>">
                   <%= signed_cents.negative? ? "" : "+" %><%= number_to_currency(signed_cents / 100.0) %>
                 </td>
-                <td class="py-2"><span class="badge badge-outline"><%= transaction.status %></span></td>
+                <td class="py-2">
+                  <span class="badge badge-outline"><%= transaction.status %></span>
+                  <% if transaction.reversed? %>
+                    <span class="badge badge-ghost text-xs ml-1">Reversed</span>
+                  <% end %>
+                </td>
                 <td class="py-2 mono text-xs"><%= transaction.request_id %></td>
                 <td class="no-print py-2 text-right">
                   <% if transaction.posting_batch.present? %>
                     <div class="flex gap-1 justify-end">
                       <%= link_to "Receipt", teller_receipt_path(request_id: transaction.request_id), class: "btn btn-ghost btn-sm" %>
                       <%= link_to "Audit", teller_receipt_path(request_id: transaction.request_id, view: "audit"), class: "btn btn-ghost btn-sm" %>
+                      <% if transaction.reversible? %>
+                        <%= link_to "Reverse", reversal_teller_transaction_path(transaction), class: "btn btn-outline btn-sm" %>
+                      <% end %>
                     </div>
                   <% else %>
                     <span class="text-slate-500 text-xs">—</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,10 @@ Rails.application.routes.draw do
     post "posting", to: "postings#create", as: :posting
     get "history", to: "transaction_history#index", as: :history
     get "receipts/:request_id", to: "receipts#show", as: :receipt
+    resources :transactions, only: [], controller: "reversals" do
+      get :reversal, on: :member, action: :new
+      post :reversal, on: :member, action: :create
+    end
     resource :teller_session, only: [ :new, :create ] do
       get :previous_closing
       patch :close

--- a/db/migrate/20260225230905_add_reversal_fields_to_teller_transactions_and_posting_batches.rb
+++ b/db/migrate/20260225230905_add_reversal_fields_to_teller_transactions_and_posting_batches.rb
@@ -1,0 +1,19 @@
+class AddReversalFieldsToTellerTransactionsAndPostingBatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :teller_transactions, :reversal_of_teller_transaction_id, :bigint
+    add_column :teller_transactions, :reversed_by_teller_transaction_id, :bigint
+    add_column :teller_transactions, :reversed_at, :datetime
+    add_column :teller_transactions, :reversal_reason_code, :string
+    add_column :teller_transactions, :reversal_memo, :text
+
+    add_index :teller_transactions, :reversal_of_teller_transaction_id
+    add_index :teller_transactions, :reversed_by_teller_transaction_id, unique: true
+
+    add_foreign_key :teller_transactions, :teller_transactions, column: :reversal_of_teller_transaction_id
+    add_foreign_key :teller_transactions, :teller_transactions, column: :reversed_by_teller_transaction_id
+
+    add_column :posting_batches, :reversal_of_posting_batch_id, :bigint
+    add_index :posting_batches, :reversal_of_posting_batch_id
+    add_foreign_key :posting_batches, :posting_batches, column: :reversal_of_posting_batch_id
+  end
+end

--- a/db/migrate/20260225233034_add_approved_by_user_id_to_teller_transactions.rb
+++ b/db/migrate/20260225233034_add_approved_by_user_id_to_teller_transactions.rb
@@ -1,0 +1,7 @@
+class AddApprovedByUserIdToTellerTransactions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :teller_transactions, :approved_by_user_id, :bigint
+    add_index :teller_transactions, :approved_by_user_id
+    add_foreign_key :teller_transactions, :users, column: :approved_by_user_id
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,7 @@ permissions = {
   "transactions.vault_transfer.create" => "Create vault transfers",
   "transactions.draft.create" => "Create draft issuances",
   "transactions.check_cashing.create" => "Create check cashing transactions",
+  "transactions.reversal.create" => "Initiate transaction reversals",
   "approvals.override.execute" => "Execute supervisor override",
   "administration.workspace.view" => "Access Administration workspace (manage branches, cash locations, users, roles)"
 }
@@ -42,7 +43,8 @@ roles = {
       "transactions.transfer.create",
       "transactions.vault_transfer.create",
       "transactions.draft.create",
-      "transactions.check_cashing.create"
+      "transactions.check_cashing.create",
+      "transactions.reversal.create"
     ]
   },
   "supervisor" => {
@@ -58,6 +60,7 @@ roles = {
       "transactions.vault_transfer.create",
       "transactions.draft.create",
       "transactions.check_cashing.create",
+      "transactions.reversal.create",
       "approvals.override.execute"
     ]
   },

--- a/test/controllers/teller/reversals_controller_test.rb
+++ b/test/controllers/teller/reversals_controller_test.rb
@@ -1,0 +1,176 @@
+require "test_helper"
+
+module Teller
+  class ReversalsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = User.take || User.create!(email_address: "reversal-ctrl@example.com", password: "password")
+      @supervisor = User.create!(email_address: "reversal-supervisor@example.com", password: "password")
+      @branch = Branch.create!(code: "996", name: "Reversal Ctrl Branch")
+      @workstation = Workstation.create!(branch: @branch, code: "RC1", name: "Reversal Ctrl WS")
+      @drawer = CashLocation.create!(
+        branch: @branch,
+        code: "RCD1",
+        name: "Reversal Ctrl Drawer",
+        location_type: "drawer"
+      )
+      @teller_session = TellerSession.create!(
+        user: @user,
+        branch: @branch,
+        workstation: @workstation,
+        cash_location: @drawer,
+        status: "open",
+        opened_at: Time.current,
+        opening_cash_cents: 10_000
+      )
+      @original = create_deposit_transaction
+      grant_posting_access(@user, @branch, @workstation)
+      grant_supervisor_access(@supervisor, @branch, @workstation)
+
+      sign_in_as(@user)
+      patch teller_context_path, params: { branch_id: @branch.id, workstation_id: @workstation.id }
+      post teller_teller_session_path, params: { opening_cash_cents: 10_000, cash_location_id: @drawer.id }
+    end
+
+    test "GET reversal renders new form when transaction is reversible" do
+      get reversal_teller_transaction_path(@original)
+
+      assert_response :success
+      assert_select "h2", "Reversal"
+      assert_select "form" do
+        assert_select "[name=?]", "reversal_reason_code"
+        assert_select "[name=?]", "reversal_memo"
+      end
+      assert_select "dl", /#{@original.request_id}/
+      assert_select "dl", /#{@original.transaction_type.titleize}/
+    end
+
+    test "GET reversal redirects when transaction is not reversible" do
+      variance = create_variance_transaction
+
+      get reversal_teller_transaction_path(variance)
+
+      assert_redirected_to teller_root_path
+      assert_equal "This transaction cannot be reversed.", flash[:alert]
+    end
+
+    test "GET reversal redirects when transaction not found" do
+      get reversal_teller_transaction_path(id: 999999)
+
+      assert_redirected_to teller_root_path
+      assert_equal "Transaction not found.", flash[:alert]
+    end
+
+    test "POST reversal creates reversal with valid approval" do
+      request_id = "reversal-test-#{@original.id}-#{Time.current.to_i}"
+      approval_token = create_approval_token(request_id)
+
+      assert_difference "TellerTransaction.count", 1 do
+        assert_difference "PostingBatch.count", 1 do
+          post reversal_teller_transaction_path(@original), params: {
+            reversal_reason_code: "ENTRY_ERROR",
+            reversal_memo: "Wrong account entered",
+            approval_token: approval_token,
+            request_id: request_id
+          }
+        end
+      end
+
+      assert_redirected_to teller_receipt_path(request_id: request_id)
+      assert_equal "Reversal posted successfully.", flash[:notice]
+
+      @original.reload
+      assert @original.reversed?
+    end
+
+    test "POST reversal requires approval token" do
+      post reversal_teller_transaction_path(@original), params: {
+        reversal_reason_code: "ENTRY_ERROR",
+        reversal_memo: "Test",
+        request_id: "reversal-no-token-#{@original.id}-#{Time.current.to_i}"
+      }
+
+      assert_response :unprocessable_entity
+      assert_match /approval/i, flash[:alert]
+    end
+
+    private
+
+    def create_deposit_transaction
+      batch = Posting::Engine.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        request_id: "deposit-rev-ctrl-#{SecureRandom.hex(4)}",
+        transaction_type: "deposit",
+        amount_cents: 5_000,
+        entries: [
+          { side: "debit", account_reference: "cash:#{@drawer.code}", amount_cents: 5_000 },
+          { side: "credit", account_reference: "1000000000001001", amount_cents: 5_000 }
+        ]
+      ).call
+      batch.teller_transaction
+    end
+
+    def create_variance_transaction
+      tt = TellerTransaction.create!(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        request_id: "variance-rev-#{SecureRandom.hex(4)}",
+        transaction_type: "session_close_variance",
+        amount_cents: 100,
+        currency: "USD",
+        status: "posted",
+        posted_at: Time.current
+      )
+      PostingBatch.create!(
+        teller_transaction: tt,
+        request_id: tt.request_id,
+        currency: "USD",
+        status: "committed",
+        committed_at: Time.current,
+        metadata: {}
+      )
+      PostingLeg.create!(posting_batch: tt.posting_batch, side: "debit", account_reference: "cash:#{@drawer.code}", amount_cents: 100, position: 0)
+      PostingLeg.create!(posting_batch: tt.posting_batch, side: "credit", account_reference: "income:variance", amount_cents: 100, position: 1)
+      tt
+    end
+
+    def create_approval_token(request_id)
+      verifier = ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base, serializer: JSON)
+      verifier.generate(
+        {
+          supervisor_user_id: @supervisor.id,
+          request_id: request_id,
+          reason: "Reversal approval",
+          policy_trigger: "transaction_reversal",
+          policy_context: {},
+          approved_at: Time.current.to_i
+        },
+        expires_in: 10.minutes
+      )
+    end
+
+    def grant_posting_access(user, branch, workstation)
+      [
+        "sessions.open",
+        "transactions.deposit.create",
+        "transactions.reversal.create"
+      ].each do |permission_key|
+        permission = Permission.find_or_create_by!(key: permission_key) { |r| r.description = permission_key }
+        role = Role.find_or_create_by!(key: "teller") { |r| r.name = "Teller" }
+        RolePermission.find_or_create_by!(role: role, permission: permission)
+        UserRole.find_or_create_by!(user: user, role: role, branch: branch, workstation: workstation)
+      end
+    end
+
+    def grant_supervisor_access(user, branch, workstation)
+      permission = Permission.find_or_create_by!(key: "approvals.override.execute") { |r| r.description = "Override" }
+      role = Role.find_or_create_by!(key: "supervisor") { |r| r.name = "Supervisor" }
+      RolePermission.find_or_create_by!(role: role, permission: permission)
+      UserRole.find_or_create_by!(user: user, role: role, branch: branch, workstation: workstation)
+    end
+  end
+end

--- a/test/models/teller_transaction_test.rb
+++ b/test/models/teller_transaction_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class TellerTransactionTest < ActiveSupport::TestCase
+  setup do
+    @user = User.take || User.create!(email_address: "reversal-test@example.com", password: "password")
+    @branch = Branch.take || Branch.create!(code: "999", name: "Test Branch")
+    @workstation = Workstation.create!(branch: @branch, code: "R99", name: "Reversal WS")
+    @drawer = CashLocation.create!(
+      branch: @branch,
+      code: "RD99",
+      name: "Reversal Drawer",
+      location_type: "drawer"
+    )
+    @teller_session = TellerSession.create!(
+      user: @user,
+      branch: @branch,
+      workstation: @workstation,
+      cash_location: @drawer,
+      status: "open",
+      opened_at: Time.current,
+      opening_cash_cents: 10_000
+    )
+  end
+
+  test "reversible? returns true for deposit" do
+    tx = create_posted_transaction("deposit")
+    assert tx.reversible?
+  end
+
+  test "reversible? returns false for session_close_variance" do
+    tx = create_posted_transaction("session_close_variance")
+    refute tx.reversible?
+  end
+
+  test "reversible? returns false for reversal" do
+    tx = create_posted_transaction("reversal")
+    refute tx.reversible?
+  end
+
+  test "reversible? returns false when already reversed" do
+    tx = create_posted_transaction("deposit")
+    assert tx.reversible?
+    reversal_tx = create_posted_transaction("reversal")
+    tx.update!(reversed_by_teller_transaction_id: reversal_tx.id)
+    tx.reload
+    refute tx.reversible?
+  end
+
+  test "reversed? returns true when reversed_by_teller_transaction_id present" do
+    tx = create_posted_transaction("deposit")
+    refute tx.reversed?
+    reversal_tx = create_posted_transaction("reversal")
+    tx.update!(reversed_by_teller_transaction_id: reversal_tx.id)
+    tx.reload
+    assert tx.reversed?
+  end
+
+  private
+
+  def create_posted_transaction(transaction_type)
+    TellerTransaction.create!(
+      user: @user,
+      teller_session: @teller_session,
+      branch: @branch,
+      workstation: @workstation,
+      request_id: "test-#{transaction_type}-#{SecureRandom.hex(4)}",
+      transaction_type: transaction_type,
+      amount_cents: 10_000,
+      currency: "USD",
+      status: "posted",
+      posted_at: Time.current
+    )
+  end
+end

--- a/test/services/posting/reversal_recipe_builder_test.rb
+++ b/test/services/posting/reversal_recipe_builder_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+module Posting
+  class ReversalRecipeBuilderTest < ActiveSupport::TestCase
+    setup do
+      @user = User.take || User.create!(email_address: "reversal-recipe@example.com", password: "password")
+      @branch = Branch.take || Branch.create!(code: "998", name: "Recipe Branch")
+      @workstation = Workstation.create!(branch: @branch, code: "RR1", name: "Recipe WS")
+      @drawer = CashLocation.create!(
+        branch: @branch,
+        code: "RRD1",
+        name: "Recipe Drawer",
+        location_type: "drawer"
+      )
+      @teller_session = TellerSession.create!(
+        user: @user,
+        branch: @branch,
+        workstation: @workstation,
+        cash_location: @drawer,
+        status: "open",
+        opened_at: Time.current,
+        opening_cash_cents: 10_000
+      )
+      @original = create_deposit_transaction
+    end
+
+    test "returns inverted legs with swapped debit/credit" do
+      entries = ReversalRecipeBuilder.new(original_teller_transaction: @original).entries
+
+      assert_equal 2, entries.size
+      assert_equal "credit", entries[0][:side]
+      assert_equal "debit", entries[1][:side]
+      assert_equal @original.posting_batch.posting_legs.order(:position).first.account_reference, entries[0][:account_reference]
+      assert_equal @original.posting_batch.posting_legs.order(:position).last.account_reference, entries[1][:account_reference]
+      assert_equal 10_000, entries[0][:amount_cents]
+      assert_equal 10_000, entries[1][:amount_cents]
+    end
+
+    test "raises when original is not reversible" do
+      variance = TellerTransaction.create!(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        request_id: "variance-#{SecureRandom.hex(4)}",
+        transaction_type: "session_close_variance",
+        amount_cents: 100,
+        currency: "USD",
+        status: "posted",
+        posted_at: Time.current
+      )
+      pb = PostingBatch.create!(
+        teller_transaction: variance,
+        request_id: variance.request_id,
+        currency: "USD",
+        status: "committed",
+        committed_at: Time.current,
+        metadata: {}
+      )
+      PostingLeg.create!(posting_batch: pb, side: "debit", account_reference: "cash:#{@drawer.code}", amount_cents: 100, position: 0)
+      PostingLeg.create!(posting_batch: pb, side: "credit", account_reference: "income:variance", amount_cents: 100, position: 1)
+
+      assert_raises(ReversalRecipeBuilder::Error) do
+        ReversalRecipeBuilder.new(original_teller_transaction: variance).entries
+      end
+    end
+
+    test "raises when original is already reversed" do
+      reversal_tt = TellerTransaction.create!(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        request_id: "reversal-#{SecureRandom.hex(4)}",
+        transaction_type: "reversal",
+        amount_cents: 10_000,
+        currency: "USD",
+        status: "posted",
+        posted_at: Time.current
+      )
+      @original.update!(reversed_by_teller_transaction_id: reversal_tt.id)
+
+      assert_raises(ReversalRecipeBuilder::Error) do
+        ReversalRecipeBuilder.new(original_teller_transaction: @original).entries
+      end
+    end
+
+    private
+
+    def create_deposit_transaction
+      tt = TellerTransaction.create!(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        request_id: "deposit-#{SecureRandom.hex(4)}",
+        transaction_type: "deposit",
+        amount_cents: 10_000,
+        currency: "USD",
+        status: "posted",
+        posted_at: Time.current
+      )
+      pb = PostingBatch.create!(
+        teller_transaction: tt,
+        request_id: tt.request_id,
+        currency: "USD",
+        status: "committed",
+        committed_at: Time.current,
+        metadata: {}
+      )
+      PostingLeg.create!(posting_batch: pb, side: "debit", account_reference: "cash:#{@drawer.code}", amount_cents: 10_000, position: 0)
+      PostingLeg.create!(posting_batch: pb, side: "credit", account_reference: "1000000000001001", amount_cents: 10_000, position: 1)
+      tt
+    end
+  end
+end

--- a/test/services/posting/reversal_service_test.rb
+++ b/test/services/posting/reversal_service_test.rb
@@ -1,0 +1,179 @@
+require "test_helper"
+
+module Posting
+  class ReversalServiceTest < ActiveSupport::TestCase
+    setup do
+      @user = User.take || User.create!(email_address: "reversal-svc@example.com", password: "password")
+      @branch = Branch.take || Branch.create!(code: "997", name: "Reversal Svc Branch")
+      @workstation = Workstation.create!(branch: @branch, code: "RS1", name: "Reversal Svc WS")
+      @drawer = CashLocation.create!(
+        branch: @branch,
+        code: "RSD1",
+        name: "Reversal Svc Drawer",
+        location_type: "drawer"
+      )
+      @teller_session = TellerSession.create!(
+        user: @user,
+        branch: @branch,
+        workstation: @workstation,
+        cash_location: @drawer,
+        status: "open",
+        opened_at: Time.current,
+        opening_cash_cents: 10_000
+      )
+      @original = create_deposit_transaction
+    end
+
+    test "creates reversal transaction and posting batch" do
+      batch = ReversalService.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        original_teller_transaction_id: @original.id,
+        reversal_reason_code: "ENTRY_ERROR",
+        reversal_memo: "Wrong account entered",
+        request_id: "reversal-#{@original.id}-#{Time.current.to_i}"
+      ).call
+
+      assert batch.is_a?(PostingBatch)
+      assert_equal "reversal", batch.teller_transaction.transaction_type
+      assert_equal @original.id, batch.teller_transaction.reversal_of_teller_transaction_id
+      assert_equal "ENTRY_ERROR", batch.teller_transaction.reversal_reason_code
+      assert_equal "Wrong account entered", batch.teller_transaction.reversal_memo
+      assert_equal @original.posting_batch.id, batch.reversal_of_posting_batch_id
+
+      @original.reload
+      assert @original.reversed?
+      assert_equal batch.teller_transaction.id, @original.reversed_by_teller_transaction_id
+      assert @original.reversed_at.present?
+    end
+
+    test "stores approved_by_user_id when provided" do
+      supervisor = User.create!(email_address: "reversal-supervisor@example.com", password: "password")
+      batch = ReversalService.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        original_teller_transaction_id: @original.id,
+        reversal_reason_code: "ENTRY_ERROR",
+        reversal_memo: "Approved reversal",
+        request_id: "reversal-approved-#{@original.id}-#{Time.current.to_i}",
+        approved_by_user_id: supervisor.id
+      ).call
+
+      assert_equal supervisor.id, batch.teller_transaction.approved_by_user_id
+      assert_equal supervisor, batch.teller_transaction.approved_by_user
+    end
+
+    test "reversal legs are inverted" do
+      batch = ReversalService.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        original_teller_transaction_id: @original.id,
+        reversal_reason_code: "DUPLICATE",
+        reversal_memo: "Duplicate post",
+        request_id: "reversal-inv-#{@original.id}-#{Time.current.to_i}"
+      ).call
+
+      original_legs = @original.posting_batch.posting_legs.order(:position)
+      reversal_legs = batch.posting_legs.order(:position)
+
+      assert_equal original_legs.size, reversal_legs.size
+      original_legs.each_with_index do |orig, i|
+        rev = reversal_legs[i]
+        assert_equal orig.account_reference, rev.account_reference
+        assert_equal orig.amount_cents, rev.amount_cents
+        assert orig.side != rev.side, "Leg #{i} should have inverted side"
+      end
+    end
+
+    test "creates cash movement with inverted direction for deposit reversal" do
+      batch = ReversalService.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        original_teller_transaction_id: @original.id,
+        reversal_reason_code: "OTHER",
+        reversal_memo: "Test",
+        request_id: "reversal-cash-#{@original.id}-#{Time.current.to_i}"
+      ).call
+
+      original_cash = @original.cash_movements.first
+      reversal_cash = batch.teller_transaction.cash_movements.first
+
+      assert original_cash.present?
+      assert reversal_cash.present?
+      assert_equal "in", original_cash.direction
+      assert_equal "out", reversal_cash.direction
+      assert_equal original_cash.amount_cents, reversal_cash.amount_cents
+    end
+
+    test "returns existing batch on idempotent retry" do
+      request_id = "reversal-idem-#{@original.id}-#{Time.current.to_i}"
+      batch1 = ReversalService.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        original_teller_transaction_id: @original.id,
+        reversal_reason_code: "ENTRY_ERROR",
+        reversal_memo: "Retry test",
+        request_id: request_id
+      ).call
+
+      batch2 = ReversalService.new(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        original_teller_transaction_id: @original.id,
+        reversal_reason_code: "OTHER",
+        reversal_memo: "Different",
+        request_id: request_id
+      ).call
+
+      assert_equal batch1.id, batch2.id
+      assert_equal 1, TellerTransaction.where(reversal_of_teller_transaction_id: @original.id).count
+    end
+
+    private
+
+    def create_deposit_transaction
+      tt = TellerTransaction.create!(
+        user: @user,
+        teller_session: @teller_session,
+        branch: @branch,
+        workstation: @workstation,
+        request_id: "deposit-svc-#{SecureRandom.hex(4)}",
+        transaction_type: "deposit",
+        amount_cents: 10_000,
+        currency: "USD",
+        status: "posted",
+        posted_at: Time.current
+      )
+      pb = PostingBatch.create!(
+        teller_transaction: tt,
+        request_id: tt.request_id,
+        currency: "USD",
+        status: "committed",
+        committed_at: Time.current,
+        metadata: {}
+      )
+      PostingLeg.create!(posting_batch: pb, side: "debit", account_reference: "cash:#{@drawer.code}", amount_cents: 10_000, position: 0)
+      PostingLeg.create!(posting_batch: pb, side: "credit", account_reference: "1000000000001001", amount_cents: 10_000, position: 1)
+      CashMovement.create!(
+        teller_transaction: tt,
+        teller_session: @teller_session,
+        cash_location: @drawer,
+        direction: "in",
+        amount_cents: 10_000
+      )
+      tt
+    end
+  end
+end


### PR DESCRIPTION
# Reverse Transaction

Add supervisor-approved reversal of posted teller transactions.

## Features

- **Reversal workflow**: Teller initiates reversal; supervisor must approve before posting
- **Reversal form** (WS-040): Reason code, memo, approval modal wired to `ReversalsController`
- **ReversalService**: Creates reversal transaction with inverted legs, links original ↔ reversal, records cash movements
- **Approval tracking**: `approved_by_user_id` on `teller_transactions` for reversals and amount-threshold approvals
- **Receipts**: Customer and audit receipts show reversal context, "Authorized by", and links between original and reversal

## Schema

- `teller_transactions`: `reversal_of_teller_transaction_id`, `reversed_by_teller_transaction_id`, `reversed_at`, `approved_by_user_id`, `reversal_reason_code`, `reversal_memo`
- `posting_batches`: `reversal_of_posting_batch_id`

## Entry Points

- Reverse button on receipt and audit views (left side, outline danger)
- Links from dashboard recent transactions, transaction history, ops session detail

## UI Layout

- Receipt/audit header: Left — Reverse (or Reversed by/Original links); Right — View toggle, Print, Back to Dashboard