### PR TITLE
Agents markdown file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# Agent Guide for BankCORE
+
+This file defines how coding agents should operate in this repository.
+It applies to the entire repo unless a deeper-level `AGENTS.md` overrides it.
+
+## Project context
+
+BankCORE is a Rails 8.1 core-banking foundation focused on:
+
+- teller session lifecycle
+- deposit/withdrawal/transfer/check-cashing flows
+- balanced and idempotent posting
+- supervisor approval interrupts and token validation
+- receipt/audit capture
+
+## Source-of-truth rules
+
+- Implemented behavior in `app/`, `config/`, and `db/` is authoritative.
+- `docs/*_concept.md` files describe target direction unless implemented code differs.
+- Keep implemented-vs-planned wording explicit in changes and summaries.
+
+## Architecture and coding preferences
+
+- Prefer Rails-native primitives already used in this codebase.
+- Keep changes small, focused, and directly related to the request.
+- Avoid unrelated refactors while completing feature or bug-fix work.
+- Preserve the health check contract at `GET /up`.
+
+## Safety-critical expectations
+
+For any changes touching money movement, approvals, or audits:
+
+- Preserve posting balance guarantees.
+- Preserve idempotency semantics for request IDs.
+- Do not bypass supervisor approval controls.
+- Do not weaken audit event coverage or traceability.
+
+## Setup and local workflow
+
+Primary setup and run commands:
+
+```bash
+bin/setup
+bin/dev
+```
+
+If using `.env` credentials locally:
+
+```bash
+set -a
+source .env
+set +a
+bin/rails-local db:prepare
+bin/dev-local
+```
+
+## Required quality checks
+
+Run the full local CI bundle when possible:
+
+```bash
+bin/ci
+```
+
+Equivalent individual checks:
+
+```bash
+bin/rubocop
+bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error
+bin/bundler-audit
+bin/importmap audit
+RAILS_ENV=test bin/rails db:test:prepare test
+```
+
+## Testing guidance for agents
+
+- Add or update tests for any material behavior change.
+- Prefer focused tests near changed code, then run broader checks as needed.
+- Do not claim completion without running at least relevant checks or explaining why not run.
+
+## Documentation guidance
+
+- Update docs when behavior changes materially.
+- Keep terminology aligned with teller/posting/audit domain language in existing docs.
+
+## Security and secrets
+
+- Never commit credentials, tokens, or private keys.
+- Use environment variables or Rails credentials for secret material.
+
+## Commit guidance
+
+- Use clear, imperative commit messages (for example: `Fix drawer prerequisite for transfer posting`).
+- Group related edits in a single commit when possible.


### PR DESCRIPTION
## Summary

- This change creates a new `AGENTS.md` file at the repository root.
- It is needed to provide clear, practical, and repo-specific guidance for coding agents, aligning with existing project conventions found in `README.md` and `CONTRIBUTING.md`.

## Scope

- [ ] Backend (Rails models/controllers/services)
- [ ] Frontend (Hotwire/Stimulus/views)
- [ ] Database (migrations/schema)
- [x] Docs
- [ ] CI/DevEx

## Checklist

- [ ] I ran focused tests for this change
- [ ] I ran `bin/rubocop`
- [ ] I ran security checks relevant to this change (`brakeman`, `bundler-audit`, `importmap audit`)
- [ ] I updated docs/status where applicable
- [x] I did not include unrelated refactors

## Test Evidence

Commands run:

```bash
git add AGENTS.md
git commit -m "Add repository AGENTS guidance for coding agents"
git push origin cursor/agents-markdown-file-2839
```

Results:

```text
The new AGENTS.md is in place and aligned to existing README/CONTRIBUTING conventions.
The file includes:
- Project context (BankCORE scope)
- Source-of-truth rules (`app/`, `config/`, `db/` vs `docs/*_concept.md`)
- Architecture/coding preferences (Rails-native, focused diffs, preserve `/up`)
- Safety-critical guardrails for posting/idempotency/approvals/audit
- Setup and local workflow commands
- Required quality checks (`bin/ci` and individual commands)
- Testing expectations for agent-driven changes
- Documentation and security guidance
- Commit message guidance
```

## Risk & Rollback

- Risk level: Low
- Potential impact: None, this is a new documentation file.
- Rollback plan: Revert the commit.

## Related

- Closes #
- Related docs/specs:

---
<p><a href="https://cursor.com/agents/bc-f9ca9000-4f3d-4fbf-8b50-9d5bff1fc220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9ca9000-4f3d-4fbf-8b50-9d5bff1fc220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

